### PR TITLE
fix issue showing true when parsing the currency option related to #7

### DIFF
--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -1,3 +1,4 @@
+#coding: utf-8
 require 'pp'
 
 module Reckon
@@ -409,7 +410,7 @@ module Reckon
           options[:encoding] = e
         end
 
-        opts.on("-c", "--currency", "Currency symbol to use, defaults to $. ex.) $, EUR") do |e|
+        opts.on("-c", "--currency '$'", "Currency symbol to use, defaults to $ (£, EUR)") do |e|
           options[:currency] = e
         end
 


### PR DESCRIPTION
When running reckon with a predefined currency I would get a true string instead of the desired currency e.g.:

 $ be reckon ... --currency 'Q'

All amount fields would come up like: -true139.63
