### PR TITLE
Make date formats explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Learn more:
         --encoding
                                      Specify an encoding for the CSV file
     -c, --currency '$'               Currency symbol to use, defaults to $ (£, EUR)
-        --date-format '%d/%m/%Y'
-                                     Force the date format (see Ruby DateTime strftime)
+        --date-format '%d/%m/%Y'     Force the date format (see Ruby DateTime strftime). Default is %m/%d/%Y. Special values include chase, nordea, germany, and guess.
         --suffixed
                                      If --currency should be used as a suffix. Defaults to false.
     -h, --help                       Show this message

--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -229,7 +229,7 @@ module Reckon
           options[:currency] = e
         end
 
-        opts.on("", "--date-format '%d/%m/%Y'", "Force the date format (see Ruby DateTime strftime)") do |d|
+        opts.on("", "--date-format '%d/%m/%Y'", "Force the date format (see Ruby DateTime strftime). Default is %m/%d/%Y. Special values include chase, nordea, germany, and guess.") do |d|
           options[:date_format] = d
         end
 

--- a/spec/reckon/app_spec.rb
+++ b/spec/reckon/app_spec.rb
@@ -7,7 +7,7 @@ require 'reckon'
 
 describe Reckon::App do
   before do
-    @chase = Reckon::App.new(:string => BANK_CSV)
+    @chase = Reckon::App.new(:string => BANK_CSV, :date_format => 'chase')
     @rows = []
     @chase.each_row_backwards { |row| @rows.push( row ) }
   end

--- a/spec/reckon/csv_parser_spec.rb
+++ b/spec/reckon/csv_parser_spec.rb
@@ -9,16 +9,17 @@ Reckon::CSVParser.settings[:testing] = true
 
 describe Reckon::CSVParser do
   before do
-    @chase = Reckon::CSVParser.new(:string => CHASE_CSV)
-    @some_other_bank = Reckon::CSVParser.new(:string => SOME_OTHER_CSV)
+    @chase = Reckon::CSVParser.new(:string => CHASE_CSV, :date_format => 'chase')
+    @some_other_bank = Reckon::CSVParser.new(:string => SOME_OTHER_CSV, :date_format => '%Y/%m/%d')
     @two_money_columns = Reckon::CSVParser.new(:string => TWO_MONEY_COLUMNS_BANK)
     @simple_csv = Reckon::CSVParser.new(:string => SIMPLE_CSV)
     @nationwide = Reckon::CSVParser.new( :string => NATIONWIDE_CSV, :csv_separator => ',', :suffixed => true, :currency => "POUND" )
-    @german_date = Reckon::CSVParser.new(:string => GERMAN_DATE_EXAMPLE)
-    @danish_kroner_nordea = Reckon::CSVParser.new(:string => DANISH_KRONER_NORDEA_EXAMPLE, :csv_separator => ';', :comma_separates_cents => true)
-    @yyyymmdd_date = Reckon::CSVParser.new(:string => YYYYMMDD_DATE_EXAMPLE)
+    @german_date = Reckon::CSVParser.new(:string => GERMAN_DATE_EXAMPLE, :date_format => 'german')
+    @danish_kroner_nordea = Reckon::CSVParser.new(:string => DANISH_KRONER_NORDEA_EXAMPLE, :date_format => 'nordea', :csv_separator => ';', :comma_separates_cents => true)
+    @yyyymmdd_date = Reckon::CSVParser.new(:string => YYYYMMDD_DATE_EXAMPLE, :date_format => '%Y%m%d')
     @spanish_date = Reckon::CSVParser.new(:string => SPANISH_DATE_EXAMPLE, :date_format => '%d/%m/%Y')
-    @english_date = Reckon::CSVParser.new(:string => ENGLISH_DATE_EXAMPLE)
+    @english_date = Reckon::CSVParser.new(:string => ENGLISH_DATE_EXAMPLE, :date_format => '%d/%m/%Y')
+    @english_date_with_default_date_format = Reckon::CSVParser.new(:string => ENGLISH_DATE_EXAMPLE)
     @ing_csv = Reckon::CSVParser.new(:string => ING_CSV, :comma_separates_cents => true )
   end
 
@@ -149,6 +150,10 @@ describe Reckon::CSVParser do
       @english_date.date_for(1).year.should == Time.parse("2009/12/24").year
       @english_date.date_for(1).month.should == Time.parse("2009/12/24").month
       @english_date.date_for(1).day.should == Time.parse("2009/12/24").day
+    end
+
+    it "should refuse to parse english dates using the default format" do
+      expect { @english_date_with_default_date_format.date_for(1) }.to raise_error(Reckon::CSVParser::ParseError)
     end
   end
 


### PR DESCRIPTION
See #18.

Took me a while to get around to this, but here's some initial code for your consideration.

With these changes, if `--date-format` is not supplied, all parsed dates are assumed to be US-style. Aliases are provided for some other types, e.g. `--date-format=chase`, `--date-format=guess` (to use Chronic).  Failure to strictly match the expected date format now results in a `CSVParser::ParseError`, so `reckon` will now be more finicky to run, but can be trusted to not mangle dates.  Files containing mixed date formats will no longer work, but I believe this is not likely to be an issue in the vast majority of places.

In order to test the failure case, I've stopped the `CSVParser` from calling `exit` deep in the call stack, but I'm not (yet) doing anything to suppress the resulting backtrace at the app level. I'll do that if you think this PR is otherwise sound.
