### PR TITLE
Fix --encoding option

### DIFF
--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -221,7 +221,7 @@ module Reckon
           options[:comma_separates_cents] = c
         end
 
-        opts.on("", "--encoding", "Specify an encoding for the CSV file") do |e|
+        opts.on("", "--encoding e", "Specify an encoding for the CSV file") do |e|
           options[:encoding] = e
         end
 


### PR DESCRIPTION
It was treated like a boolean flag and encoding string given at cli was
ignored causing:

```
lib/reckon/csv_parser.rb:236:in `force_encoding': no implicit conversion of true into String (TypeError)
```
