### PR TITLE
assume utf-8 encoding instead of binary

### DIFF
--- a/lib/reckon/csv_parser.rb
+++ b/lib/reckon/csv_parser.rb
@@ -2,7 +2,7 @@
 require 'pp'
 
 module Reckon
-  class CSVParser 
+  class CSVParser
     attr_accessor :options, :csv_data, :money_column_indices, :date_column_index, :description_column_indices, :money_column, :date_column
 
     def initialize(options = {})
@@ -132,7 +132,7 @@ module Reckon
         puts "please report this issue to us so we can take a look!\n"
       end
     end
-    
+
     # Some csv files negative/positive amounts are indicated in separate account
     def detect_sign_column
       return if columns[0].length <= 2 # This test needs requires more than two rows otherwise will lead to false positives
@@ -141,13 +141,13 @@ module Reckon
         column = columns[ @money_column_indices[0] - 1 ]
         signs = column.uniq
       end
-      if (signs.length != 2 && 
+      if (signs.length != 2 &&
           (@money_column_indices[0] + 1 < columns.length))
         column = columns[ @money_column_indices[0] + 1 ]
         signs = column.uniq
       end
       if signs.length == 2
-        negative_first = true 
+        negative_first = true
         negative_first = false if signs[0] == "Bij" || signs[0].downcase =~ /^cr/ # look for known debit indicators
         @money_column.each_with_index do |money, i|
           if negative_first && column[i] == signs[0]
@@ -233,7 +233,7 @@ module Reckon
       data = options[:string] || File.read(options[:file])
 
       if RUBY_VERSION =~ /^1\.9/ || RUBY_VERSION =~ /^2/
-        data = data.force_encoding(options[:encoding] || 'BINARY').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '?')
+        data = data.force_encoding(options[:encoding] || 'UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '?')
         csv_engine = CSV
       else
         csv_engine = FasterCSV


### PR DESCRIPTION
Right now encoding does not work if the source data is in UTF already:

```
irb(main):009:0> "тест".force_encoding('utf-8').encode('utf-8', :invalid => :replace, :undef => :replace, :replace => '?')
=> "тест"
irb(main):010:0> "тест".force_encoding('binary').encode('utf-8', :invalid => :replace, :undef => :replace, :replace => '?')
=> "????????"
```