### PR TITLE
Unattended mode and custom tokens support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,25 @@ Assuming you have Ruby and [Rubygems](http://rubygems.org/pages/download) instal
 First, login to your bank and export your transaction data as a CSV file.
 
 To see how the CSV parses:
-  
+
     reckon -f bank.csv -p
 
 If your CSV file has a header on the first line, include `--contains-header`.
 
 To convert to ledger format and label everything, do:
-  
+
     reckon -f bank.csv -o output.dat
 
 To have reckon learn from an existing ledger file, provide it with -l:
-  
+
     reckon -f bank.csv -l 2010.dat -o output.dat
 
 Learn more:
 
     > reckon -h
-    
+
     Usage: Reckon.rb [options]
+
 
     -f, --file FILE                  The CSV file to parse
     -a, --account name               The Ledger Account this file is for
@@ -43,23 +44,58 @@ Learn more:
     -l, --learn-from FILE            An existing ledger file to learn accounts from
         --ignore-columns 1,2,5
                                      Columns to ignore in the CSV file - the first column is column 1
-        --contains-header
-                                     The first row of the CSV is a header and should be skipped
+        --contains-header [N]
+                                     The first row of the CSV is a header and should be skipped. Optionally add the number of rows to skip.
         --csv-separator ','
                                      Separator for parsing the CSV - default is comma.
         --comma-separates-cents
                                      Use comma instead of period to deliminate dollars from cents when parsing ($100,50 instead of $100.50)
         --encoding 'UTF-8'
-                                     Specify an encoding for the CSV file; usually not required.
+                                     Specify an encoding for the CSV file; not usually needed
     -c, --currency '$'               Currency symbol to use, defaults to $ (£, EUR)
         --date-format '%d/%m/%Y'
                                      Force the date format (see Ruby DateTime strftime)
+    -u, --unattended                 Don't ask questions and guess all the accounts automatically. Used with --learn-from or --account-tokens options.
+    -t, --account-tokens FILE        File with account tokens
+        --default_into_account name
+                                     Default into account
+        --default_outof_account name
+                                     Default 'out of' account
         --suffixed
                                      If --currency should be used as a suffix. Defaults to false.
     -h, --help                       Show this message
         --version                    Show version
 
 If you find CSV files that it can't parse, send me examples or pull requests!
+
+## Unattended mode
+
+You can run reckon in a non-interactive mode.
+To guess the accounts reckon can use an existing ledger file or a token file with keywords.
+
+`reckon --unattended -l 2010.dat -f bank.csv -o ledger.dat`
+
+`reckon --unattended --account-tokens tokens.yaml -f bank.csv -o ledger.dat`
+
+Here's an example of `tokens.yaml`:
+
+```
+Income:
+  Salary:
+    - 'LÖN'
+    - 'Salary'
+Expenses:
+  Bank:
+    - 'Comission'
+    - 'MasterCard'
+  Rent:
+    - '0011223344' # Landlord bank number
+'[Internal:Transfer]': # Virtual account
+  - '4433221100' # Your own account number
+```
+
+If reckon can not guess the accounts it will use `Income:Unknown` or `Expenses:Unknown` names.
+You can override them with `--default_outof_account` and `--default_into_account` options.
 
 ## Note on Patches/Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Learn more:
         --date-format '%d/%m/%Y'
                                      Force the date format (see Ruby DateTime strftime)
     -u, --unattended                 Don't ask questions and guess all the accounts automatically. Used with --learn-from or --account-tokens options.
-    -t, --account-tokens FILE        File with account tokens
-        --default_into_account name
+    -t, --account-tokens FILE        YAML file with manually-assigned tokens for each account (see README)
+        --default-into-account name
                                      Default into account
-        --default_outof_account name
+        --default-outof-account name
                                      Default 'out of' account
         --suffixed
                                      If --currency should be used as a suffix. Defaults to false.

--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -49,6 +49,7 @@ module Reckon
 
     def learn!
       if options[:account_tokens_file]
+        fail "#{options[:account_tokens_file]} doesn't exist!" unless File.exists?(options[:account_tokens_file])
         extract_account_tokens(YAML.load_file(options[:account_tokens_file])).each do |account, tokens|
           tokens.each { |t| learn_about_account(account, t) }
         end
@@ -88,7 +89,7 @@ module Reckon
           seen_anything_new = true
         end
 
-        possible_answers = weighted_account_match( row ).map { |a| a[:account] }
+        possible_answers = weighted_account_match( row ).map! { |a| a[:account] }
 
         ledger = if row[:money] > 0
           if options[:unattended]
@@ -115,7 +116,6 @@ module Reckon
             into_account = possible_answers.first || options[:default_into_account] || 'Expenses:Unknown'
           else
             into_account = ask("To which account did this money go? ([account]/[q]uit/[s]kip) ") { |q|
-              possible_answers = weighted_account_match( row ).map! { |a| a[:account] }
               q.completion = possible_answers
               q.readline = true
               q.default = possible_answers.first
@@ -284,15 +284,15 @@ module Reckon
           options[:unattended] = n
         end
 
-        opts.on("-t", "--account-tokens FILE", "File with account tokens") do |a|
+        opts.on("-t", "--account-tokens FILE", "YAML file with manually-assigned tokens for each account (see README)") do |a|
           options[:account_tokens_file] = a
         end
 
-        opts.on("", "--default_into_account name", "Default into account") do |a|
+        opts.on("", "--default-into-account name", "Default into account") do |a|
           options[:default_into_account] = a
         end
 
-        opts.on("", "--default_outof_account name", "Default 'out of' account") do |a|
+        opts.on("", "--default-outof-account name", "Default 'out of' account") do |a|
           options[:default_outof_account] = a
         end
 

--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -18,6 +18,11 @@ module Reckon
       learn!
     end
 
+    def interactive_output(str)
+      return if options[:unattended]
+      puts str
+    end
+
     def learn_from(ledger)
       LedgerParser.new(ledger).entries.each do |entry|
         entry[:accounts].each do |account|
@@ -44,7 +49,6 @@ module Reckon
 
     def learn!
       if options[:account_tokens_file]
-        puts options[:account_tokens_file].inspect
         extract_account_tokens(YAML.load_file(options[:account_tokens_file])).each do |account, tokens|
           tokens.each { |t| learn_about_account(account, t) }
         end
@@ -72,12 +76,12 @@ module Reckon
     def walk_backwards
       seen_anything_new = false
       each_row_backwards do |row|
-        puts Terminal::Table.new(:rows => [ [ row[:pretty_date], row[:pretty_money], row[:description] ] ])
+        interactive_output Terminal::Table.new(:rows => [ [ row[:pretty_date], row[:pretty_money], row[:description] ] ])
 
         if already_seen?(row)
-          puts "NOTE: This row is very similar to a previous one!"
+          interactive_output "NOTE: This row is very similar to a previous one!"
           if !seen_anything_new
-            puts "Skipping..."
+            interactive_output "Skipping..."
             next
           end
         else
@@ -99,7 +103,7 @@ module Reckon
 
           finish if out_of_account == "quit" || out_of_account == "q"
           if out_of_account == "skip" || out_of_account == "s"
-            puts "Skipping"
+            interactive_output "Skipping"
             next
           end
 
@@ -119,7 +123,7 @@ module Reckon
           end
           finish if into_account == "quit" || into_account == 'q'
           if into_account == "skip" || into_account == 's'
-            puts "Skipping"
+            interactive_output "Skipping"
             next
           end
 
@@ -135,7 +139,7 @@ module Reckon
 
     def finish
       options[:output_file].close unless options[:output_file] == STDOUT
-      puts "Exiting."
+      interactive_output "Exiting."
       exit
     end
 
@@ -195,7 +199,7 @@ module Reckon
           t << [ row[:pretty_date], row[:pretty_money], row[:description] ]
         end
       end
-      puts output
+      interactive_output output
     end
 
     def each_row_backwards

--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -1,5 +1,6 @@
 #coding: utf-8
 require 'pp'
+require 'yaml'
 
 module Reckon
   class App
@@ -32,12 +33,26 @@ module Reckon
       seen[row[:pretty_date]] && seen[row[:pretty_date]][row[:pretty_money]]
     end
 
-    def learn!
-      if options[:existing_ledger_file]
-        fail "#{options[:existing_ledger_file]} doesn't exist!" unless File.exists?(options[:existing_ledger_file])
-        ledger_data = File.read(options[:existing_ledger_file])
-        learn_from(ledger_data)
+    def extract_account_tokens(subtree, account = nil)
+      if subtree.is_a?(Array)
+        { account => subtree }
+      else
+        at = subtree.map { |k, v| extract_account_tokens(v, [account, k].compact.join(':')) }
+        at.inject({}) { |k, v| k = k.merge(v)}
       end
+    end
+
+    def learn!
+      if options[:account_tokens_file]
+        puts options[:account_tokens_file].inspect
+        extract_account_tokens(YAML.load_file(options[:account_tokens_file])).each do |account, tokens|
+          tokens.each { |t| learn_about_account(account, t) }
+        end
+      end
+      return unless options[:existing_ledger_file]
+      fail "#{options[:existing_ledger_file]} doesn't exist!" unless File.exists?(options[:existing_ledger_file])
+      ledger_data = File.read(options[:existing_ledger_file])
+      learn_from(ledger_data)
     end
 
     def learn_about_account(account, data)
@@ -69,13 +84,19 @@ module Reckon
           seen_anything_new = true
         end
 
+        possible_answers = weighted_account_match( row ).map { |a| a[:account] }
+
         ledger = if row[:money] > 0
-          out_of_account = ask("Which account provided this income? ([account]/[q]uit/[s]kip) ") { |q|
-            possible_answers = weighted_account_match( row ).map! { |a| a[:account] }
-            q.completion = possible_answers
-            q.readline = true
-            q.default = possible_answers.first 
-          }
+          if options[:unattended]
+            out_of_account = possible_answers.first || options[:default_outof_account] || 'Income:Unknown'
+          else
+            out_of_account = ask("Which account provided this income? ([account]/[q]uit/[s]kip) ") { |q|
+              q.completion = possible_answers
+              q.readline = true
+              q.default = possible_answers.first
+            }
+          end
+
           finish if out_of_account == "quit" || out_of_account == "q"
           if out_of_account == "skip" || out_of_account == "s"
             puts "Skipping"
@@ -86,12 +107,16 @@ module Reckon
                          [options[:bank_account], row[:pretty_money]],
                          [out_of_account, row[:pretty_money_negated]] )
         else
-          into_account = ask("To which account did this money go? ([account]/[q]uit/[s]kip) ") { |q|
-            possible_answers = weighted_account_match( row ).map! { |a| a[:account] }
-            q.completion = possible_answers
-            q.readline = true
-            q.default = possible_answers.first 
-          }
+          if options[:unattended]
+            into_account = possible_answers.first || options[:default_into_account] || 'Expenses:Unknown'
+          else
+            into_account = ask("To which account did this money go? ([account]/[q]uit/[s]kip) ") { |q|
+              possible_answers = weighted_account_match( row ).map! { |a| a[:account] }
+              q.completion = possible_answers
+              q.readline = true
+              q.default = possible_answers.first
+            }
+          end
           finish if into_account == "quit" || into_account == 'q'
           if into_account == "skip" || into_account == 's'
             puts "Skipping"
@@ -103,7 +128,7 @@ module Reckon
                          [options[:bank_account], row[:pretty_money]] )
         end
 
-        learn_from(ledger)
+        learn_from(ledger) unless options[:account_tokens_file]
         output(ledger)
       end
     end
@@ -145,12 +170,15 @@ module Reckon
           :account => account }
       end
       account_vectors.sort! {|a, b| b[:cosine] <=> a[:cosine] }
-      return account_vectors
-    end
 
-    def guess_account( row )
-      account_vectors = weighted_account_match( row )
-      account_vectors.first && account_vectors.first[:account]
+      # Return empty set if no accounts matched so that we can fallback to the defaults in the unattended mode
+      if options[:unattended]
+        if account_vectors.first && account_vectors.first[:account]
+          account_vectors = [] if account_vectors.first[:cosine] == 0
+        end
+      end
+
+      return account_vectors
     end
 
     def ledger_format(row, line1, line2)
@@ -173,9 +201,9 @@ module Reckon
     def each_row_backwards
       rows = []
       (0...@csv_parser.columns.first.length).to_a.each do |index|
-        rows << { :date => @csv_parser.date_for(index), 
+        rows << { :date => @csv_parser.date_for(index),
           :pretty_date => @csv_parser.pretty_date_for(index),
-          :pretty_money => @csv_parser.pretty_money_for(index), 
+          :pretty_money => @csv_parser.pretty_money_for(index),
           :pretty_money_negated => @csv_parser.pretty_money_for(index, :negate),
           :money => @csv_parser.money_for(index),
           :description => @csv_parser.description_for(index) }
@@ -248,6 +276,22 @@ module Reckon
           options[:date_format] = d
         end
 
+        opts.on("-u", "--unattended", "Don't ask questions and guess all the accounts automatically. Used with --learn-from or --account-tokens options.") do |n|
+          options[:unattended] = n
+        end
+
+        opts.on("-t", "--account-tokens FILE", "File with account tokens") do |a|
+          options[:account_tokens_file] = a
+        end
+
+        opts.on("", "--default_into_account name", "Default into account") do |a|
+          options[:default_into_account] = a
+        end
+
+        opts.on("", "--default_outof_account name", "Default 'out of' account") do |a|
+          options[:default_outof_account] = a
+        end
+
         opts.on("", "--suffixed", "If --currency should be used as a suffix. Defaults to false.") do |e|
           options[:suffixed] = e
         end
@@ -275,6 +319,9 @@ module Reckon
       end
 
       unless options[:bank_account]
+
+        fail "Please specify --account for the unattended mode" if options[:unattended]
+
         options[:bank_account] = ask("What is the account name of this bank account in Ledger? ") do |q|
           q.readline = true
           q.validate = /^.{2,}$/

--- a/spec/data_fixtures/tokens.yaml
+++ b/spec/data_fixtures/tokens.yaml
@@ -1,0 +1,14 @@
+Income:
+  Salary:
+    - 'LÖN'
+    - 'Salary'
+Expenses:
+  Bank:
+    - 'Comission'
+    - 'MasterCard'
+  Rent:
+    - '0011223344' # Landlord bank number
+  Books:
+    - 'Book'
+'[Internal:Transfer]': # Virtual account
+  - '4433221100' # Your own account number

--- a/spec/reckon/app_spec.rb
+++ b/spec/reckon/app_spec.rb
@@ -6,27 +6,70 @@ require 'rubygems'
 require 'reckon'
 
 describe Reckon::App do
-  before do
-    @chase = Reckon::App.new(:string => BANK_CSV)
-    @chase.learn_from( BANK_LEDGER )
-    @rows = []
-    @chase.each_row_backwards { |row| @rows.push( row ) }
-  end
+  context 'with chase csv input' do
+    before do
+      @chase = Reckon::App.new(:string => BANK_CSV)
+      @chase.learn_from( BANK_LEDGER )
+      @rows = []
+      @chase.each_row_backwards { |row| @rows.push( row ) }
+    end
 
-  describe "each_row_backwards" do
-    it "should return rows with hashes" do
-      @rows[0][:pretty_date].should == "2009/12/10"
-      @rows[0][:pretty_money].should == " $2105.00"
-      @rows[0][:description].should == "CREDIT; Some Company vendorpymt PPD ID: 5KL3832735"
-      @rows[1][:pretty_date].should == "2009/12/11"
-      @rows[1][:pretty_money].should == "-$116.22"
-      @rows[1][:description].should == "CREDIT; PAYPAL TRANSFER PPD ID: PAYPALSDSL"
+    describe "each_row_backwards" do
+      it "should return rows with hashes" do
+        @rows[0][:pretty_date].should == "2009/12/10"
+        @rows[0][:pretty_money].should == " $2105.00"
+        @rows[0][:description].should == "CREDIT; Some Company vendorpymt PPD ID: 5KL3832735"
+        @rows[1][:pretty_date].should == "2009/12/11"
+        @rows[1][:pretty_money].should == "-$116.22"
+        @rows[1][:description].should == "CREDIT; PAYPAL TRANSFER PPD ID: PAYPALSDSL"
+      end
+    end
+
+    describe "weighted_account_match" do
+      it "should guess the correct account" do
+        @chase.weighted_account_match( @rows[7] ).first[:account].should == "Expenses:Books"
+      end
     end
   end
 
-  describe "weighted_account_match" do
-    it "should guess the correct account" do
-      @chase.weighted_account_match( @rows[7] ).first[:account].should == "Expenses:Books"
+  context 'unattended mode with chase csv input' do
+    before do
+      @output_file = StringIO.new
+      @chase = Reckon::App.new(:string => BANK_CSV, :unattended => true, :output_file => @output_file)
+    end
+
+    describe 'walk backwards' do
+      it 'should assign Income:Unknown and Expenses:Unknown by default' do
+        @chase.walk_backwards
+        @output_file.string.scan('Expenses:Unknown').count.should == 6
+        @output_file.string.scan('Income:Unknown').count.should == 3
+      end
+
+      it 'should change default account names' do
+        @chase = Reckon::App.new(:string => BANK_CSV,
+                                 :unattended => true,
+                                 :output_file => @output_file,
+                                 :default_into_account => 'Expenses:Default',
+                                 :default_outof_account => 'Income:Default')
+        @chase.walk_backwards
+        @output_file.string.scan('Expenses:Default').count.should == 6
+        @output_file.string.scan('Income:Default').count.should == 3
+      end
+
+      it 'should learn from a ledger file' do
+        @chase.learn_from( BANK_LEDGER )
+        @chase.walk_backwards
+        @output_file.string.scan('Expenses:Books').count.should == 1
+      end
+
+      it 'should learn from an account tokens file' do
+        @chase = Reckon::App.new(:string => BANK_CSV,
+                                 :unattended => true,
+                                 :output_file => @output_file,
+                                 :account_tokens_file => 'spec/data_fixtures/tokens.yaml')
+        @chase.walk_backwards
+        @output_file.string.scan('Expenses:Books').count.should == 1
+      end
     end
   end
 

--- a/spec/reckon/app_spec.rb
+++ b/spec/reckon/app_spec.rb
@@ -24,12 +24,12 @@ describe Reckon::App do
     end
   end
 
-  describe "guess_account" do
+  describe "weighted_account_match" do
     it "should guess the correct account" do
-      @chase.guess_account( @rows[7] ).should == "Expenses:Books"
+      @chase.weighted_account_match( @rows[7] ).first[:account].should == "Expenses:Books"
     end
   end
-  
+
   #DATA
   BANK_CSV = (<<-CSV).strip
     DEBIT,20091224120000[0:GMT],"HOST 037196321563 MO        12/22SLICEHOST",-85.00


### PR DESCRIPTION
This change adds 2 features:

**Unattended mode**

Basically, as mentioned in https://github.com/cantino/reckon/issues/3 but with 2 default (in/out) account options.

**Custom tokens for the classifier**

In order to have better control on how the account guessing is done.