### PR TITLE
[RFC] Fix #42: Work with suntrust double column csv files

### DIFF
--- a/lib/reckon/csv_parser.rb
+++ b/lib/reckon/csv_parser.rb
@@ -95,10 +95,9 @@ module Reckon
       output_columns = []
       columns.each_with_index do |column, index|
         if index == a
-          new_column = []
-          column.each_with_index do |row, row_index|
-            new_column << row + " " + (columns[b][row_index] || '')
-          end
+          new_column = MoneyColumn.new( column )
+            .merge!( MoneyColumn.new( columns[b] ) )
+            .map { |m| m.amount.to_s }
           output_columns << new_column
         elsif index == b
           # skip

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -49,7 +49,7 @@ module Reckon
       m = value.match( /(\D*)(\d+\.\d\d)(\D*)/ ) || value.match(/^(.*?)([\d\.]+)(\D*)$/)
       if m 
         amount = m[2].to_f
-        if (m[1].match( /^-/ ) || m[1].match( /-$/  ))
+        if (m[1].match( /^[\(-]/ ) || m[1].match( /-$/  ))
           amount *= -1
         end
         return Money.new( amount, options )

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -43,12 +43,23 @@ module Reckon
     end
 
     def Money::from_s( value, options = {} )
+      # Empty string is treated as money with value 0
       return Money.new( 0.00, options ) if value.empty?
+
+      # Remove 1000 separaters and replace , with . if comma_separates_cents
+      # 1.000,00 -> 1000.00
       value = value.gsub(/\./, '').gsub(/,/, '.') if options[:comma_separates_cents]
       value = value.gsub(/,/, '')
-      m = value.match( /(\D*)(\d+\.\d\d)(\D*)/ ) || value.match(/^(.*?)([\d\.]+)(\D*)$/)
+
+      money_format_regex = /^(.*?)(\d+\.\d\d)/ # Money has two decimal precision
+      any_number_regex = /^(.*?)([\d\.]+)/
+
+      # Prefer matching the money_format, match any number otherwise
+      m = value.match( money_format_regex ) || 
+        value.match( any_number_regex )
       if m 
         amount = m[2].to_f
+        # Check whether the money had a - or (, which indicates negative amounts
         if (m[1].match( /^[\(-]/ ) || m[1].match( /-$/  ))
           amount *= -1
         end

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -45,7 +45,14 @@ module Reckon
     def Money::from_s( value, options = {} )
       return nil if value.empty?
       value = value.gsub(/\./, '').gsub(/,/, '.') if options[:comma_separates_cents]
-      amount = value.gsub(/[^\d\.]/, '').to_f
+      value = value.gsub(/,/, '')
+      if m = value.match( /\d+\.\d\d/ )
+        amount = m[-1].to_f
+      elsif m = value.match(/[\d\.]+/)
+        amount = m[-1].to_f
+      else
+        return nil
+      end
       amount *= -1 if value =~ /[\(\-]/
       Money.new( amount, options )
     end

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -4,7 +4,7 @@ require 'pp'
 module Reckon
   class Money
     include Comparable
-    attr_accessor :amount, :currency, :suffixed, :original_prefix, :original_postfix
+    attr_accessor :amount, :currency, :suffixed
     def initialize( amount, options = {} )
       if options[:inverse]
         @amount = -1*amount.to_f
@@ -52,13 +52,7 @@ module Reckon
         if (m[1].match( /^-/ ) || m[1].match( /-$/  ))
           amount *= -1
         end
-        money = Money.new( amount, options )
-        money.original_prefix = m[1]
-        if (amount < 0)
-          money.original_prefix.sub!('-','')
-        end
-        money.original_postfix = m[3]
-        return money
+        return Money.new( amount, options )
       else
         return nil
       end
@@ -93,16 +87,12 @@ module Reckon
       invert = true if self.positive? && other_column.positive?
       self.each_with_index do |mon, i|
         other = other_column[i]
-        if (mon && other &&
-            (mon.original_postfix != other.original_postfix ||
-                mon.original_prefix != other.original_prefix))
-          return nil
-        end
-        if mon && (!other || other.amount == 0.0)
+        return nil if (!mon || !other)
+        if mon != 0.00 && other == 0.0
           if invert
             self[i]= -mon
           end
-        elsif (!mon || mon.amount == 0.0) && other
+        elsif mon == 0.00 && other != 0.00
           self[i] = other
         else
           return nil

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -79,11 +79,11 @@ module Reckon
       invert = true if self.positive? && other_column.positive?
       self.each_with_index do |mon, i|
         other = other_column[i]
-        if mon && !other
+        if mon && (!other || other.amount == 0.0)
           if invert
             self[i]= -mon
           end
-        elsif !mon && other
+        elsif (!mon || mon.amount == 0.0) && other
           self[i] = other
         else
           return nil

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -43,7 +43,7 @@ module Reckon
     end
 
     def Money::from_s( value, options = {} )
-      return nil if value.empty?
+      return Money.new( 0.00, options ) if value.empty?
       value = value.gsub(/\./, '').gsub(/,/, '.') if options[:comma_separates_cents]
       value = value.gsub(/,/, '')
       m = value.match( /(\D*)(\d+\.\d\d)(\D*)/ ) || value.match(/^(.*?)([\d\.]+)(\D*)$/)

--- a/spec/reckon/csv_parser_spec.rb
+++ b/spec/reckon/csv_parser_spec.rb
@@ -222,16 +222,6 @@ describe Reckon::CSVParser do
     end
   end
 
-  describe "merge_columns" do
-    it "should work on adjacent columns" do
-      @simple_csv.merge_columns(0,1).should == [["entry1 entry2", "entry4 entry5"], ["entry3", "entry6"]]
-    end
-
-    it "should work on non-adjacent columns" do
-      @simple_csv.merge_columns(0,2).should == [["entry1 entry3", "entry4 entry6"], ["entry2", "entry5"]]
-    end
-  end
-
   # Data
 
   SIMPLE_CSV = "entry1,entry2,entry3\nentry4,entry5,entry6"

--- a/spec/reckon/csv_parser_spec.rb
+++ b/spec/reckon/csv_parser_spec.rb
@@ -12,6 +12,7 @@ describe Reckon::CSVParser do
     @chase = Reckon::CSVParser.new(:string => CHASE_CSV)
     @some_other_bank = Reckon::CSVParser.new(:string => SOME_OTHER_CSV)
     @two_money_columns = Reckon::CSVParser.new(:string => TWO_MONEY_COLUMNS_BANK)
+    @suntrust_csv = Reckon::CSVParser.new(:string => SUNTRUST_CSV)
     @simple_csv = Reckon::CSVParser.new(:string => SIMPLE_CSV)
     @nationwide = Reckon::CSVParser.new( :string => NATIONWIDE_CSV, :csv_separator => ',', :suffixed => true, :currency => "POUND" )
     @german_date = Reckon::CSVParser.new(:string => GERMAN_DATE_EXAMPLE)
@@ -65,6 +66,7 @@ describe Reckon::CSVParser do
       @chase.money_column_indices.should == [3]
       @some_other_bank.money_column_indices.should == [3]
       @two_money_columns.money_column_indices.should == [3, 4]
+      @suntrust_csv.money_column_indices.should == [3, 4]
       @nationwide.money_column_indices.should == [3, 4]
       @harder_date_example_csv.money_column_indices.should == [1]
       @danish_kroner_nordea.money_column_indices.should == [3]
@@ -283,6 +285,16 @@ describe Reckon::CSVParser do
     3/27/2008,Check - 0000000112,112,-$800.00,"","$1,498.57"
     3/26/2008,Check - 0000000251,251,-$88.55,"","$1,298.57"
     3/26/2008,Check - 0000000251,251,"","+$88.55","$1,298.57"
+  CSV
+
+  SUNTRUST_CSV = (<<-CSV).strip
+    11/01/2014,0, Deposit,0,500.00,500.00
+    11/02/2014,101,Check,100.00,0,400.00
+    11/03/2014,102,Check,100.00,0,300.00
+    11/04/2014,103,Check,100.00,0,200.00
+    11/05/2014,104,Check,100.00,0,100.00
+    11/06/2014,105,Check,100.00,0,0.00
+    11/17/2014,0, Deposit,0,700.00,700.00
   CSV
 
   NATIONWIDE_CSV = (<<-CSV).strip

--- a/spec/reckon/money_column_spec.rb
+++ b/spec/reckon/money_column_spec.rb
@@ -35,6 +35,9 @@ describe Reckon::MoneyColumn do
       Reckon::MoneyColumn.new( ["1.00", ""] ).merge!( 
         Reckon::MoneyColumn.new( ["", "-2.00"] ) ).should == [ 
           Reckon::Money.new( 1.00 ), Reckon::Money.new( -2.00 ) ]
+      Reckon::MoneyColumn.new( ["1.00", "0"] ).merge!( 
+        Reckon::MoneyColumn.new( ["0", "-2.00"] ) ).should == [ 
+          Reckon::Money.new( 1.00 ), Reckon::Money.new( -2.00 ) ]
     end
 
     it "should return nil if columns cannot be merged" do

--- a/spec/reckon/money_column_spec.rb
+++ b/spec/reckon/money_column_spec.rb
@@ -49,8 +49,6 @@ describe Reckon::MoneyColumn do
     it "should return nil if columns cannot be merged" do
       Reckon::MoneyColumn.new( ["1.00", ""] ).merge!( 
         Reckon::MoneyColumn.new( ["1.00", "-2.00"] ) ).should == nil
-      Reckon::MoneyColumn.new( ["AB1.00C", "AB0C"] ).merge!( 
-          Reckon::MoneyColumn.new( ["AB0C", "AB-2.00D"] ) ).should == nil
 
       Reckon::MoneyColumn.new( ["From1", "Names"] ).merge!( 
           Reckon::MoneyColumn.new( ["Acc", "NL28 INGB 1200 3244 16,21817"] ) ).should == nil

--- a/spec/reckon/money_column_spec.rb
+++ b/spec/reckon/money_column_spec.rb
@@ -38,11 +38,22 @@ describe Reckon::MoneyColumn do
       Reckon::MoneyColumn.new( ["1.00", "0"] ).merge!( 
         Reckon::MoneyColumn.new( ["0", "-2.00"] ) ).should == [ 
           Reckon::Money.new( 1.00 ), Reckon::Money.new( -2.00 ) ]
-    end
+      Reckon::MoneyColumn.new( ["AB1.00C", ""] ).merge!( 
+        Reckon::MoneyColumn.new( ["", "AB-2.00C"] ) ).should == [ 
+          Reckon::Money.new( 1.00 ), Reckon::Money.new( -2.00 ) ]
+      Reckon::MoneyColumn.new( ["AB1.00C", "AB0C"] ).merge!( 
+        Reckon::MoneyColumn.new( ["AB0C", "AB-2.00C"] ) ).should == [ 
+          Reckon::Money.new( 1.00 ), Reckon::Money.new( -2.00 ) ]
+     end
 
     it "should return nil if columns cannot be merged" do
       Reckon::MoneyColumn.new( ["1.00", ""] ).merge!( 
         Reckon::MoneyColumn.new( ["1.00", "-2.00"] ) ).should == nil
+      Reckon::MoneyColumn.new( ["AB1.00C", "AB0C"] ).merge!( 
+          Reckon::MoneyColumn.new( ["AB0C", "AB-2.00D"] ) ).should == nil
+
+      Reckon::MoneyColumn.new( ["From1", "Names"] ).merge!( 
+          Reckon::MoneyColumn.new( ["Acc", "NL28 INGB 1200 3244 16,21817"] ) ).should == nil
     end
 
     it "should invert first column if both positive" do

--- a/spec/reckon/money_spec.rb
+++ b/spec/reckon/money_spec.rb
@@ -37,6 +37,12 @@ describe Reckon::Money do
       Reckon::Money::from_s( "2.00A1" ).should == 2
     end
 
+    it "should handle arbitrary prefixes and postfixes" do
+      Reckon::Money::from_s( "AB1.00C" ).should == 1
+      Reckon::Money::from_s( "AB0C" ).should == 0
+      Reckon::Money::from_s( "AB-2.00C" ).should == -2
+    end
+
     it "should return nil if no numbers are found" do
       Reckon::Money::from_s( "BAC" ).should == nil
     end

--- a/spec/reckon/money_spec.rb
+++ b/spec/reckon/money_spec.rb
@@ -42,6 +42,12 @@ describe Reckon::Money do
       Reckon::Money::from_s( "BAC" ).should == nil
     end
 
+    it "should store original prefix and postfix" do
+      Reckon::Money::from_s( "2A1B" ).amount.should == 1.00 
+      Reckon::Money::from_s( "2A1B" ).original_prefix.should == "2A" 
+      Reckon::Money::from_s( "2A1B" ).original_postfix.should == "B" 
+    end
+
   end
 
   describe "pretty" do

--- a/spec/reckon/money_spec.rb
+++ b/spec/reckon/money_spec.rb
@@ -28,6 +28,20 @@ describe Reckon::Money do
       Reckon::Money::from_s( "$2.000,00", :comma_separates_cents => true ).should == 2000.00
       Reckon::Money::from_s( "-$1,025.67" ).should == -1025.67 
     end
+
+    it "should keep numbers together" do
+      Reckon::Money::from_s( "1A1" ).should == 1
+    end
+
+    it "should prefer numbers with precision of two" do
+      Reckon::Money::from_s( "1A2.00" ).should == 2
+      Reckon::Money::from_s( "2.00A1" ).should == 2
+    end
+
+    it "should return nil if no numbers are found" do
+      Reckon::Money::from_s( "BAC" ).should == nil
+    end
+
   end
 
   describe "pretty" do

--- a/spec/reckon/money_spec.rb
+++ b/spec/reckon/money_spec.rb
@@ -46,6 +46,9 @@ describe Reckon::Money do
       Reckon::Money::from_s( "2A1B" ).amount.should == 1.00 
       Reckon::Money::from_s( "2A1B" ).original_prefix.should == "2A" 
       Reckon::Money::from_s( "2A1B" ).original_postfix.should == "B" 
+      Reckon::Money::from_s( "2A-1B" ).amount.should == -1.00 
+      Reckon::Money::from_s( "2A-1B" ).original_prefix.should == "2A" 
+      Reckon::Money::from_s( "2A-1B" ).original_postfix.should == "B" 
     end
 
   end

--- a/spec/reckon/money_spec.rb
+++ b/spec/reckon/money_spec.rb
@@ -40,16 +40,6 @@ describe Reckon::Money do
     it "should return nil if no numbers are found" do
       Reckon::Money::from_s( "BAC" ).should == nil
     end
-
-    it "should store original prefix and postfix" do
-      Reckon::Money::from_s( "2A1B" ).amount.should == 1.00 
-      Reckon::Money::from_s( "2A1B" ).original_prefix.should == "2A" 
-      Reckon::Money::from_s( "2A1B" ).original_postfix.should == "B" 
-      Reckon::Money::from_s( "2A-1B" ).amount.should == -1.00 
-      Reckon::Money::from_s( "2A-1B" ).original_prefix.should == "2A" 
-      Reckon::Money::from_s( "2A-1B" ).original_postfix.should == "B" 
-    end
-
   end
 
   describe "pretty" do

--- a/spec/reckon/money_spec.rb
+++ b/spec/reckon/money_spec.rb
@@ -19,9 +19,8 @@ describe Reckon::Money do
       Reckon::Money::from_s( "$-1025,67", :comma_separates_cents => true ).should == -1025.67 
     end
 
-    it "should return nil for an empty string" do
-      Reckon::Money::from_s( "" ).should == nil
-      Reckon::Money::from_s( "" ).should_not == 0
+    it "should return 0 for an empty string" do
+      Reckon::Money::from_s( "" ).should == 0
     end
 
     it "should handle 1000 indicators correctly" do


### PR DESCRIPTION
- [x] Add test for suntrust
- [x] Improve Money.from_s method
- [x] csvparser merge columns should use moneycolumn.merge

### The problem:

Suntrust csv has two money columns, one for debit and one for credit. Reckon used to deal with this by appending two columns (space separated) with each other and then testing them for a money column. This works fine if one column is always empty -> ["2.00", ""], ["", "1.00"] merged is ["2.00" + " " + "", "" + " " + "1.00"]
but the suntrust one had 0.00 instead of "" -> ["2.00", "0"], ["0", "1.00"] merged is ["2.00" + " " + "0", "0" + " " + "1.00"], which clearly leads to problems.

### The solution

First convert the columns to money columns and then merge them like that. The only downside of this solution is that when converting to money we lose some information (prefixes and suffixes). This initially led to some problems when converting two columns that had numbers in them, but clearly where not money columns (account numbers etc). I solved this by making the Money.from_s function stricter.