### PR TITLE
Better ISO 8601 dates support

### DIFF
--- a/lib/reckon/csv_parser.rb
+++ b/lib/reckon/csv_parser.rb
@@ -2,7 +2,7 @@
 require 'pp'
 
 module Reckon
-  class CSVParser 
+  class CSVParser
     attr_accessor :options, :csv_data, :money_column_indices, :date_column_index, :description_column_indices, :money_column, :date_column
 
     def initialize(options = {})
@@ -63,7 +63,7 @@ module Reckon
           date_score += 5 if entry =~ /^[\-\/\.\d:\[\]]+$/
           date_score += entry.gsub(/[^\-\/\.\d:\[\]]/, '').length if entry.gsub(/[^\-\/\.\d:\[\]]/, '').length > 3
           date_score -= entry.gsub(/[\-\/\.\d:\[\]]/, '').length
-          date_score += 30 if entry =~ /^\d+[:\/\.]\d+[:\/\.]\d+([ :]\d+[:\/\.]\d+)?$/
+          date_score += 30 if entry =~ /^\d+[:\/\.-]\d+[:\/\.-]\d+([ :]\d+[:\/\.]\d+)?$/
           date_score += 10 if entry =~ /^\d+\[\d+:GMT\]$/i
 
           # Try to determine if this is a balance column
@@ -132,7 +132,7 @@ module Reckon
         puts "please report this issue to us so we can take a look!\n"
       end
     end
-    
+
     # Some csv files negative/positive amounts are indicated in separate account
     def detect_sign_column
       return if columns[0].length <= 2 # This test needs requires more than two rows otherwise will lead to false positives
@@ -141,13 +141,13 @@ module Reckon
         column = columns[ @money_column_indices[0] - 1 ]
         signs = column.uniq
       end
-      if (signs.length != 2 && 
+      if (signs.length != 2 &&
           (@money_column_indices[0] + 1 < columns.length))
         column = columns[ @money_column_indices[0] + 1 ]
         signs = column.uniq
       end
       if signs.length == 2
-        negative_first = true 
+        negative_first = true
         negative_first = false if signs[0] == "Bij" || signs[0].downcase =~ /^cr/ # look for known debit indicators
         @money_column.each_with_index do |money, i|
           if negative_first && column[i] == signs[0]

--- a/lib/reckon/money.rb
+++ b/lib/reckon/money.rb
@@ -39,7 +39,7 @@ module Reckon
         (@amount >= 0 ? " " : "") + sprintf("%0.2f #{@currency}", @amount * (negate ? -1 : 1))
       else
         (@amount >= 0 ? " " : "") + sprintf("%0.2f", @amount * (negate ? -1 : 1)).gsub(/^((\-)|)(?=\d)/, "\\1#{@currency}")
-      end      
+      end
     end
 
     def Money::from_s( value, options = {} )
@@ -108,11 +108,13 @@ module Reckon
           value = [$1, $2, $3].join("/") if value =~ /^(\d{4})(\d{2})(\d{2})\d+\[\d+\:GMT\]$/ # chase format
           value = [$3, $2, $1].join("/") if value =~ /^(\d{2})\.(\d{2})\.(\d{4})$/            # german format
           value = [$3, $2, $1].join("/") if value =~ /^(\d{2})\-(\d{2})\-(\d{4})$/            # nordea format
+          value = [$1, $2, $3].join("/") if value =~ /^(\d{4})\-(\d{2})\-(\d{2})$/            # yyyy-mm-dd format
           value = [$1, $2, $3].join("/") if value =~ /^(\d{4})(\d{2})(\d{2})/                 # yyyymmdd format
+
 
           unless @endian_precedence # Try to detect endian_precedence
             reg_match = value.match( /^(\d\d)\/(\d\d)\/\d\d\d?\d?/ )
-            # If first one is not \d\d/\d\d/\d\d\d?\d set it to default 
+            # If first one is not \d\d/\d\d/\d\d\d?\d set it to default
             if !reg_match
               @endian_precedence = [:middle, :little]
             elsif reg_match[1].to_i > 12
@@ -122,7 +124,7 @@ module Reckon
             end
           end
         end
-        self.push( value ) 
+        self.push( value )
       end
       # if endian_precedence still nil, raise error
       unless @endian_precedence || options[:date_format]
@@ -132,10 +134,10 @@ module Reckon
 
     def for( index )
       value = self.at( index )
-      guess = Chronic.parse(value, :context => :past, 
+      guess = Chronic.parse(value, :context => :past,
                             :endian_precedence => @endian_precedence )
       if guess.to_i < 953236800 && value =~ /\//
-        guess = Chronic.parse((value.split("/")[0...-1] + [(2000 + value.split("/").last.to_i).to_s]).join("/"), :context => :past, 
+        guess = Chronic.parse((value.split("/")[0...-1] + [(2000 + value.split("/").last.to_i).to_s]).join("/"), :context => :past,
                               :endian_precedence => @endian_precedence)
       end
       guess

--- a/spec/reckon/csv_parser_spec.rb
+++ b/spec/reckon/csv_parser_spec.rb
@@ -30,7 +30,7 @@ describe Reckon::CSVParser do
     @chase.settings[:testing].should be_true
     Reckon::CSVParser.settings[:testing].should be_true
   end
-  
+
   describe "parse" do
     it "should work with foreign character encodings" do
       app = Reckon::CSVParser.new(:file => File.expand_path(File.join(File.dirname(__FILE__), "..", "data_fixtures", "extratofake.csv")))
@@ -48,7 +48,7 @@ describe Reckon::CSVParser do
       @simple_csv.columns.should == [["entry1", "entry4"], ["entry2", "entry5"], ["entry3", "entry6"]]
       @chase.columns.length.should == 4
     end
-    
+
     it "should be ok with empty lines" do
       lambda {
         Reckon::CSVParser.new(:string => "one,two\nthree,four\n\n\n\n\n").columns.should == [['one', 'three'], ['two', 'four']]
@@ -60,7 +60,7 @@ describe Reckon::CSVParser do
     before do
       @harder_date_example_csv = Reckon::CSVParser.new(:string => HARDER_DATE_EXAMPLE)
     end
-    
+
     it "should detect the money column" do
       @chase.money_column_indices.should == [3]
       @some_other_bank.money_column_indices.should == [3]
@@ -86,6 +86,7 @@ describe Reckon::CSVParser do
       @french_csv.date_column_index.should == 2
       @broker_canada.date_column_index.should == 0
       @intuit_mint.date_column_index.should == 0
+      Reckon::CSVParser.new(:string => '2014-01-13,"22211100000",-10').date_column_index.should == 0
     end
 
     it "should consider all other columns to be description columns" do
@@ -121,7 +122,7 @@ describe Reckon::CSVParser do
       @danish_kroner_nordea.money_for(5).should == -655.00
       @yyyymmdd_date.money_for(0).should == -123.45
       @ing_csv.money_for(0).should == -136.13
-      @ing_csv.money_for(1).should == 375.00 
+      @ing_csv.money_for(1).should == 375.00
       @austrian_csv.money_for(0).should == -18.00
       @austrian_csv.money_for(2).should == 120.00
       @french_csv.money_for(0).should == -10.00
@@ -294,8 +295,8 @@ describe Reckon::CSVParser do
 
   ING_CSV = (<<-CSV).strip
     20121115,From1,Acc,T1,IC,Af,"136,13",Incasso,SEPA Incasso, Opm1
-    20121112,Names,NL28 INGB 1200 3244 16,21817,GT,Bij,"375,00", Opm2       
-    20091117,Names,NL28 INGB 1200 3244 16,21817,GT,Af,"257,50", Opm3      
+    20121112,Names,NL28 INGB 1200 3244 16,21817,GT,Bij,"375,00", Opm2
+    20091117,Names,NL28 INGB 1200 3244 16,21817,GT,Af,"257,50", Opm3
   CSV
 
   HARDER_DATE_EXAMPLE = (<<-CSV).strip
@@ -377,7 +378,7 @@ describe Reckon::CSVParser do
     2013-06-27,2013-06-27,Dividend,ICICI BK SPONSORED ADR,IBN,100,,,66.70,USD
     2013-06-19,2013-06-24,Buy,ISHARES S&P/TSX CAPPED REIT IN,XRE,300,15.90,CDN,-4779.95,CAD
     2013-06-17,2013-06-17,Contribution,CONTRIBUTION,,,,,600.00,CAD
-    2013-05-22,2013-05-22,Dividend,NATBK,NA,70,,,58.10,CAD 
+    2013-05-22,2013-05-22,Dividend,NATBK,NA,70,,,58.10,CAD
   CSV
 
   INTUIT_MINT_EXAMPLE = (<<-CSV).strip
@@ -389,5 +390,6 @@ describe Reckon::CSVParser do
 "1/30/2014","Transfer to CBT (Savings)","[CW] TF 0004#3409-797","500.00","debit","Transfer","Chequing","",""
 "1/30/2014","Costco","[PR]COSTCO WHOLESAL","559.96","debit","Business Services","Chequing","",""
   CSV
+
 
 end

--- a/spec/reckon/date_column_spec.rb
+++ b/spec/reckon/date_column_spec.rb
@@ -8,11 +8,11 @@ require 'reckon'
 describe Reckon::DateColumn do
   describe "initialize" do
     it "should detect us and world time" do
-      Reckon::DateColumn.new( ["01/02/2013", "01/14/2013"] ).endian_precedence.should == [:middle] 
-      Reckon::DateColumn.new( ["01/02/2013", "14/01/2013"] ).endian_precedence.should == [:little] 
+      Reckon::DateColumn.new( ["01/02/2013", "01/14/2013"] ).endian_precedence.should == [:middle]
+      Reckon::DateColumn.new( ["01/02/2013", "14/01/2013"] ).endian_precedence.should == [:little]
     end
     it "should set endian_precedence to default when date format cannot be misinterpreted" do
-      Reckon::DateColumn.new( ["2013/01/02"] ).endian_precedence.should == [:middle,:little] 
+      Reckon::DateColumn.new( ["2013/01/02"] ).endian_precedence.should == [:middle,:little]
     end
     it "should raise an error when in doubt" do
       expect{ Reckon::DateColumn.new( ["01/02/2013", "01/03/2013"] )}.to raise_error( StandardError )
@@ -20,20 +20,23 @@ describe Reckon::DateColumn do
   end
   describe "for" do
     it "should detect the date" do
-      Reckon::DateColumn.new( ["13/12/2013"] ).for( 0 ).should == 
-        Time.new( 2013, 12, 13, 12 ) 
-      Reckon::DateColumn.new( ["01/14/2013"] ).for( 0 ).should == 
-        Time.new( 2013, 01, 14, 12 ) 
-      Reckon::DateColumn.new( ["13/12/2013", "21/11/2013"] ).for( 1 ).should == 
-        Time.new( 2013, 11, 21, 12 ) 
+      Reckon::DateColumn.new( ["13/12/2013"] ).for( 0 ).should ==
+        Time.new( 2013, 12, 13, 12 )
+      Reckon::DateColumn.new( ["01/14/2013"] ).for( 0 ).should ==
+        Time.new( 2013, 01, 14, 12 )
+      Reckon::DateColumn.new( ["13/12/2013", "21/11/2013"] ).for( 1 ).should ==
+        Time.new( 2013, 11, 21, 12 )
+      Reckon::DateColumn.new( ["2013-11-21"] ).for( 0 ).should ==
+        Time.new( 2013, 11, 21, 12 )
+
     end
 
     it "should correctly use endian_precedence" do
-      Reckon::DateColumn.new( ["01/02/2013", "01/14/2013"] ).for(0).should == 
+      Reckon::DateColumn.new( ["01/02/2013", "01/14/2013"] ).for(0).should ==
         Time.new( 2013, 01, 02, 12 )
-      Reckon::DateColumn.new( ["01/02/2013", "14/01/2013"] ).for(0).should ==  
+      Reckon::DateColumn.new( ["01/02/2013", "14/01/2013"] ).for(0).should ==
         Time.new( 2013, 02, 01, 12 )
     end
   end
 end
- 
+


### PR DESCRIPTION
This change puts a higher date_score on the columns looking like iso8601-dates.
Otherwise reckon detects the second column as a date_column in the example below:

```
2014-01-13,"22211100000",-10000
```