### PR TITLE
Ignore empty description columns

### DIFF
--- a/lib/reckon/app.rb
+++ b/lib/reckon/app.rb
@@ -39,7 +39,10 @@ module Reckon
     end
 
     def extract_account_tokens(subtree, account = nil)
-      if subtree.is_a?(Array)
+      if subtree.nil?
+        puts "Warning: empty #{account} tree"
+        {}
+      elsif subtree.is_a?(Array)
         { account => subtree }
       else
         at = subtree.map { |k, v| extract_account_tokens(v, [account, k].compact.join(':')) }

--- a/lib/reckon/csv_parser.rb
+++ b/lib/reckon/csv_parser.rb
@@ -44,7 +44,7 @@ module Reckon
     end
 
     def description_for(index)
-      description_column_indices.map { |i| columns[i][index] }.join("; ").squeeze(" ").gsub(/(;\s+){2,}/, '').strip
+      description_column_indices.map { |i| columns[i][index] }.reject { |a| a.empty? }.join("; ").squeeze(" ").gsub(/(;\s+){2,}/, '').strip
     end
 
     def evaluate_columns(cols)

--- a/spec/reckon/csv_parser_spec.rb
+++ b/spec/reckon/csv_parser_spec.rb
@@ -188,6 +188,12 @@ describe Reckon::CSVParser do
       @chase.description_for(1).should == "CHECK; CHECK 2656"
       @chase.description_for(7).should == "CREDIT; PAYPAL TRANSFER PPD ID: PAYPALSDSL"
     end
+
+    it "should not append empty description column" do
+      parser = Reckon::CSVParser.new(:string => '01/09/2015,05354 SUBWAY,8.19,,',:date_format => '%d/%m/%Y')
+      parser.description_column_indices.should == [1, 4]
+      parser.description_for(0).should == '05354 SUBWAY'
+    end
   end
 
   describe "pretty_money_for" do


### PR DESCRIPTION
Reckon extracts a list of tokens not from a CSV row itself, but from a generated ledger description line using `tr.downcase.split(/[\s\-]/)` which also includes `;` in the list of the tokens.

If recon detects two description columns and one of them is empty it generates unnecessary `;` in the ledger row and it breaks tokenization.

This PR does not fix the root cause of the problem but it fixes the immediate issue in https://github.com/cantino/reckon/issues/51 and adds some cosmetic benefits.

To fix the root cause probably need to improve token extraction and extend token list by splitting the description by non-word symbols...