### PR TITLE
Add 'complex tokens' to tokens.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ Expenses:
   Bank:
     - 'Comission'
     - 'MasterCard'
+    # The following will guess `Expenses:Bank` if the account of the
+    # CSV (set with `--account`) matches the given regexp.
+    - Pattern: 'Visa'
+      Account: /^Liabilities:Visa/i
+    # The following will skip all guesses for the given pattern.
+    - Pattern: 'Mastercard'
+      Skip: true
   Rent:
     - '0011223344' # Landlord bank number
   Hosting:

--- a/spec/data_fixtures/complex_tokens.yaml
+++ b/spec/data_fixtures/complex_tokens.yaml
@@ -1,0 +1,18 @@
+Income:
+  Salary:
+    - 'LÖN'
+    - 'Salary'
+Expenses:
+  Paypal:
+    - 'HELLO'
+    - /BLAHBLAH/
+    - Pattern: 'PAYPAL'
+      Account: /^Liabilities:/
+  Books:
+    - Pattern: /Book Store/
+      Account: /^Assets:Bank/
+    - Pattern: /Book Store/
+      Account: /^Assets:Another/
+    - Pattern: /Blarg/
+      Account: /^Assets:Bank/
+      Skip: true

--- a/spec/reckon/app_spec.rb
+++ b/spec/reckon/app_spec.rb
@@ -71,6 +71,21 @@ describe Reckon::App do
         @output_file.string.scan('Expenses:Books').count.should == 1
         @output_file.string.scan('Expenses:Websites').count.should == 2
       end
+
+      it 'should support complex tokens' do
+        @chase = Reckon::App.new(
+          :string => BANK_CSV,
+          :unattended => true,
+          :output_file => @output_file,
+          :account_tokens_file => 'spec/data_fixtures/complex_tokens.yaml',
+          :bank_account => 'Assets:Bank:Checking'
+        )
+
+        @chase.walk_backwards
+        @output_file.string.scan('Expenses:Books').count.should == 1
+        @output_file.string.scan('Expenses:Paypal').count.should == 0
+      end
+
     end
   end
 


### PR DESCRIPTION
This PR adds 'complex tokens' that look like this:

``` yaml
Expenses:
  Personal:
    - McDonalds
    - Pattern: /OFFSHORE SERVICE MARGINS/
      Account: Liabilities:Visa:Personal
  Business:
    Bank Fees:
      - Pattern: /OFFSHORE SERVICE MARGINS/
        Account: Liabilities:Visa:Business
```

The motivation being that sometimes transactions will have the same
description, but depending on the statement that they were recorded in,
need to go into different accounts.

It also adds a `skip` feature which I use like this:

``` yaml
Global:
  - Pattern: /PAYMENT RECEIVED THANK YOU/
    Account: Liabilities:Visa:Personal
    Skip: true
```

Things like credit card payments are usually recorded on two separate
statements (e.g Checking and Visa,) therefore it's desirable to skip one
of these transactions in order to prevent doubling them up.

Some more features could be added to the complex token in the future,
I'm thinking it'd be nice to define rules so that e.g a sum coming out
of a statement account can go into multiple accounts based on given proportions
