### PR TITLE
Cosine similarity should use all docs tokens. not just matched tokens.

### DIFF
--- a/lib/reckon/cosine_similarity.rb
+++ b/lib/reckon/cosine_similarity.rb
@@ -1,47 +1,52 @@
 require 'matrix'
 require 'set'
 
-# Implementation of consine similarity using TF-IDF for vectorization.
-# Used to suggest which account a transaction should be assigned to
+# Implementation of cosine similarity using TF-IDF for vectorization.
+#
+# In information retrieval, tf–idf, short for term frequency–inverse document frequency,
+# is a numerical statistic that is intended to reflect how important a word is to a
+# document in a collection or corpus
+#
+# Cosine Similarity a measurement to determine how similar 2 documents are to each other.
+#
+# These weights and measures are used to suggest which account a transaction should be
+# assigned to.
 module Reckon
   class CosineSimilarity
+    DocumentInfo = Struct.new(:tokens, :accounts)
+
     def initialize(options)
+      @docs = DocumentInfo.new({}, {})
       @options = options
-      @tokens = {}
-      @accounts = Hash.new(0)
     end
 
     def add_document(account, doc)
-      tokenize(doc).each do |n|
+      tokens = tokenize(doc)
+      LOGGER.info "doc tokens: #{tokens}"
+      tokens.each do |n|
         (token, count) = n
 
-        @tokens[token] ||= {}
-        @tokens[token][account] ||= 0
-        @tokens[token][account] += count
-        @accounts[account] += count
+        @docs.tokens[token] ||= Hash.new(0)
+        @docs.tokens[token][account] += count
+        @docs.accounts[account] ||= Hash.new(0)
+        @docs.accounts[account][token] += count
       end
     end
 
     # find most similar documents to query
     def find_similar(query)
-      (query_scores, corpus_scores) = td_idf_scores_for(query)
+      LOGGER.info "find_similar #{query}"
 
-      query_vector = Vector.elements(query_scores, false)
+      accounts = docs_to_check(query).map do |a|
+        [a, tfidf(@docs.accounts[a])]
+      end
 
-      # For each doc, calculate the similarity to the query
-      suggestions = corpus_scores.map do |account, scores|
-        acct_vector = Vector.elements(scores, false)
+      q = tfidf(tokenize(query))
 
-        acct_query_dp = acct_vector.inner_product(query_vector)
-        # similarity is a float between 1 and -1, where 1 is exactly the same and -1 is
-        # exactly opposite
-        # see https://en.wikipedia.org/wiki/Cosine_similarity
-        # cos(theta) = (A . B) / (||A|| ||B||)
-        # where A . B is the "dot product" and ||A|| is the magnitude of A
-        # ruby has the 'matrix' library we can use to do these calculations.
+      suggestions = accounts.map do |a, d|
         {
-          similarity: acct_query_dp / (acct_vector.magnitude * query_vector.magnitude),
-          account: account,
+          similarity: calc_similarity(q, d),
+          account: a
         }
       end.select { |n| n[:similarity] > 0 }.sort_by { |n| -n[:similarity] }
 
@@ -52,50 +57,51 @@ module Reckon
 
     private
 
-    def td_idf_scores_for(query)
-      query_tokens = tokenize(query)
-      corpus = Set.new
-      corpus_scores = {}
-      query_scores = []
-      num_docs = @accounts.length
-
-      query_tokens.each do |n|
-        (token, _count) = n
-        next unless @tokens[token]
-        corpus = corpus.union(Set.new(@tokens[token].keys))
+    def docs_to_check(query)
+      return tokenize(query).reduce(Set.new) do |corpus, t|
+        corpus.union(Set.new(@docs.tokens[t[0]]&.keys))
       end
+    end
 
-      query_tokens.each do |n|
-        (token, count) = n
+    def tfidf(tokens)
+      scores = {}
 
-        # if no other docs have token, ignore it
-        next unless @tokens[token]
-
-        ## First, calculate scores for our query as we're building scores for the corpus
-        query_scores << calc_tf_idf(
-          count,
-          query_tokens.length,
-          @tokens[token].length,
-          num_docs
+      tokens.each do |t, n|
+        scores[t] = calc_tf_idf(
+          n,
+          tokens.length,
+          @docs.tokens[t]&.length&.to_f || 0,
+          @docs.accounts.length
         )
-
-        ## Next, calculate for the corpus, where our "account" is a document
-        corpus.each do |account|
-          corpus_scores[account] ||= []
-
-          corpus_scores[account] << calc_tf_idf(
-            (@tokens[token][account] || 0),
-            @accounts[account].to_f,
-            @tokens[token].length.to_f,
-            num_docs
-          )
-        end
       end
-      [query_scores, corpus_scores]
+
+      return scores
+    end
+
+    # Cosine similarity is used to compare how similar 2 documents are. Returns a float
+    # between 1 and -1, where 1 is exactly the same and -1 is exactly opposite.
+    #
+    # see https://en.wikipedia.org/wiki/Cosine_similarity
+    # cos(theta) = (A . B) / (||A|| ||B||)
+    # where A . B is the "dot product" and ||A|| is the magnitude of A
+    #
+    # The variables A and B are the set of unique terms in q and d.
+    #
+    # For example, when q = "big red balloon" and d ="small green balloon" then the
+    # variables are (big,red,balloon,small,green) and a = (1,1,1,0,0) and b =
+    # (0,0,1,1,1).
+    #
+    # query and doc are hashes of token => tf/idf score
+    def calc_similarity(query, doc)
+      tokens = Set.new(query.keys + doc.keys)
+
+      a = Vector.elements(tokens.map { |n| query[n] || 0 }, false)
+      b = Vector.elements(tokens.map { |n| doc[n] || 0 }, false)
+
+      return a.inner_product(b) / (a.magnitude * b.magnitude)
     end
 
     def calc_tf_idf(token_count, num_words_in_doc, df, num_docs)
-
       # tf(t,d) = count of t in d / number of words in d
       tf = token_count / num_words_in_doc.to_f
 
@@ -109,14 +115,13 @@ module Reckon
     end
 
     def tokenize(str)
-      mk_tokens(str).inject(Hash.new(0)) do |memo, n|
+      mk_tokens(str).each_with_object(Hash.new(0)) do |n, memo|
         memo[n] += 1
-        memo
       end.to_a
     end
 
     def mk_tokens(str)
-      str.downcase.tr(';', ' ').tr("'", '').split(/[^a-z0-9.]+/)
+      str.downcase.tr(';', ' ').tr("'", '').split(/[^a-z0-9.]+/).reject(&:empty?)
     end
   end
 end

--- a/spec/cosine_training_and_test.rb
+++ b/spec/cosine_training_and_test.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require 'pp'
+
+require 'reckon'
+
+ledger_file = ARGV[0]
+account = ARGV[1]
+seed = ARGV[2] ? ARGV[2].to_i : Random.new_seed
+
+ledger = Reckon::LedgerParser.new(File.read(ledger_file))
+matcher = Reckon::CosineSimilarity.new({})
+
+train = []
+test = []
+
+def has_account(account, entry)
+  entry[:accounts].map { |a| a[:name] }.include?(account)
+end
+
+entries = ledger.entries.select { |e| has_account(account, e) }
+
+r = Random.new(seed)
+entries.length.times do |i|
+  r.rand < 0.9 ? train << i : test << i
+end
+
+train.each do |i|
+  entry = entries[i]
+  entry[:accounts].each do |a|
+    matcher.add_document(
+      a[:name],
+      [entry[:desc], a[:amount]].join(" ")
+    )
+  end
+end
+
+result = [nil] * test.length
+test.each do |i|
+  entry = entries[i]
+  matches = matcher.find_similar(
+    entry[:desc] + " " + entry[:accounts][0][:amount].to_s
+  )
+
+  if !matches[0] || !has_account(matches[0][:account], entry)
+    result[i] = [entry, matches]
+  end
+end
+
+# pp result.compact
+puts "using #{seed} as random seed"
+puts "true: #{result.count(nil)} false: #{result.count { |v| !v.nil? }}"


### PR DESCRIPTION
Cosine similarity should compare the set of the 2 documents tokens, not just the tokens
shared between the two docs.

This fixes #106

Confirmed that this improved matching performance by constructing a training and test
set of data from my personal ledger file, and compared 10 runs with the same seeds
between the old implementation and the new.  In 8 out of 10 runs, the new implementation
outperformed the old.

true: 1429 false: -4
true: 1410 false: -7
true: 1363 false: 4
true: 1460 false: -5
true: 1434 false: 5
true: 1421 false: -25
true: 1431 false: -10
true: 1451 false: -31
true: 1414 false: -26
true: 1412 false: -26

test command:
for i in (seq 1 10);
  spec/cosine_training_and_test.rb \
    ~/notes/finance/current.ledger \
    Liabilities:ChaseCreditCard \
    $i;
end