### PR TITLE
Add support for multiple money columns

### DIFF
--- a/lib/reckon/csv_parser.rb
+++ b/lib/reckon/csv_parser.rb
@@ -162,13 +162,30 @@ module Reckon
     def detect_columns
       results = evaluate_columns(columns)
 
+      # We keep money_column options for backwards compatibility reasons, while
+      # adding option to specify multiple money_columns
       if options[:money_column]
         self.money_column_indices = [options[:money_column] - 1]
+
+      # One or two columns can be specified as money_columns
+      elsif options[:money_columns]
+        if options[:money_columns].length == 1
+          self.money_column_indices = [options[:money_column] - 1]
+        elsif options[:money_columns].length == 2
+          first_idx = options[:money_columns][0] - 1
+          second_idx = options[:money_columns][1] - 1
+          self.money_column_indices = [first_idx, second_idx]
+        else
+          puts "Unable to determine money columns, use --money-columns to specify the 1 or 2 column(s) reckon should use."
+        end
+
+      # If no money_column(s) argument is supplied, try to automatically infer money_column(s)
       else
         self.money_column_indices = results.select { |n| n[:is_money_column] }.map { |n| n[:index] }
         if self.money_column_indices.length == 1
           puts "Using column #{money_column_indices.first + 1} as the money column.  Use --money-colum to specify a different one."
         elsif self.money_column_indices.length == 2
+          puts "Using columns #{money_column_indices[0] + 1} and #{money_column_indices[1] + 1} as money column. Use --money-columns to specify different ones."
           found_double_money_column(*self.money_column_indices)
         else
           puts "Unable to determine a money column, use --money-column to specify the column reckon should use."

--- a/lib/reckon/options.rb
+++ b/lib/reckon/options.rb
@@ -44,6 +44,10 @@ module Reckon
           options[:money_column] = col
         end
 
+        opts.on("", "--money-columns 2,3", "Column number of the money columns, starts from 1 (1 or 2 columns)") do |ignore|
+          options[:money_columns] = ignore.split(",").map(&:to_i)
+        end
+
         opts.on("", "--raw-money", "Don't format money column (for stocks)") do |n|
           options[:raw] = n
         end

--- a/spec/integration/two_money_columns_manual/input.csv
+++ b/spec/integration/two_money_columns_manual/input.csv
@@ -1,0 +1,5 @@
+Date,Summary,Withdrawal,Deposit,Ending balance,Remarks,In/outward transfer account,Notes
+2021/07/02,Expense,200,,999,,,
+2021/07/02,Expense,100,,999,,,
+2021/07/08,Transfer,,200,999,,,In1
+2021/07/08,Transfer,500,,999,,,Out1

--- a/spec/integration/two_money_columns_manual/output.ledger
+++ b/spec/integration/two_money_columns_manual/output.ledger
@@ -1,0 +1,16 @@
+2021-07-02	Expense; 999
+	Expenses:Unknown			
+	Assets:Bank:Checking			-$100.00
+
+2021-07-02	Expense; 999
+	Expenses:Unknown			
+	Assets:Bank:Checking			-$200.00
+
+2021-07-08	Transfer; 999; In1
+	Assets:Bank:Checking			 $200.00
+	Expenses:Unknown			
+
+2021-07-08	Transfer; 999; Out1
+	Expenses:Unknown			
+	Assets:Bank:Checking			-$500.00
+

--- a/spec/integration/two_money_columns_manual/test_args
+++ b/spec/integration/two_money_columns_manual/test_args
@@ -1,0 +1,1 @@
+-f input.csv --unattended --account Assets:Bank:Checking --money-columns 3,4


### PR DESCRIPTION
This is useful in cases where there are two money columns and this can't easily be automatically detected.

- Adds command line option for `--money-columns`
- Updates parser to deal with 1-2 specified money columns
- Keep current money_column option for backwards compatibility
- Adds integration test case for this

---

Things to note:

- Tested with `./spec/integration/test.sh spec/integration/two_money_columns_manual`

- Running  `> reckon -f spec/integration/two_money_columns_manual/input.csv --unattended --account Assets:Bank:Checking` results in `Using column 3 as the money column.  Use --money-colum to specify a different one.`. Possibly due to negative money score (?). Same with `--ignore-column 5`

- I'm not a Ruby dev so code might be unidiomatic in some way.