### PR TITLE
121 require date

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,13 +9,10 @@ name: Build Status
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,17 +23,18 @@ jobs:
           - 3.0
           # Ubuntu 20.04
           - 2.7
+          # For date_column errors
+          - 2.6
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Update package
       run: sudo apt-get update
     - name: Install packages
       run: sudo apt-get -y install ledger hledger
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+      # use ruby/setup-ruby@v1 (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
-      # uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems

--- a/bin/build-new-version.sh
+++ b/bin/build-new-version.sh
@@ -4,20 +4,25 @@ set -e
 
 VERSION=$1
 
+if [ -z "$TOKEN" ]; then
+    echo "\$TOKEN var must be your github api token"
+    exit 1
+fi
+
 echo "Install github_changelog_generator"
 gem install --user github_changelog_generator
 
 echo "Update 'lib/reckon/version.rb'"
-echo -e "module Reckon\n  VERSION=\"$VERSION\"\nend" > lib/reckon/version.rb
+echo -e "module Reckon\n  VERSION = \"$VERSION\"\nend" > lib/reckon/version.rb
 echo "Run `bundle install` to build updated Gemfile.lock"
 bundle install
 echo "Run changelog generator (requires $TOKEN to be your github token)"
-github_changelog_generator -u cantino -p reckon -t $TOKEN --future-release v$VERSION
+github_changelog_generator -u cantino -p reckon -t "$TOKEN" --future-release "v$VERSION"
 echo "Commit changes"
 git add CHANGELOG.md lib/reckon/version.rb Gemfile.lock
 git commit -m "Release $VERSION"
 echo "Tag release"
-git tag v$VERSION
+git tag "v$VERSION"
 echo "Build new gem"
 gem build reckon.gemspec
 echo "Push changes and tags"

--- a/bin/build-new-version.sh
+++ b/bin/build-new-version.sh
@@ -29,3 +29,4 @@ echo "Push changes and tags"
 echo "git push && git push --tags"
 echo "Push new gem"
 echo "gem push reckon-$VERSION.gem"
+gh release create "v$VERSION" "reckon-$VERSION.gem" --draft --generate-notes

--- a/lib/reckon/date_column.rb
+++ b/lib/reckon/date_column.rb
@@ -1,7 +1,13 @@
+# frozen_string_literal: true
+
+require 'date'
+
 module Reckon
+  # Handle date columns in csv
   class DateColumn < Array
     attr_accessor :endian_precedence
-    def initialize( arr = [], options = {} )
+
+    def initialize(arr = [], options = {})
       # output date format
       @ledger_date_format = options[:ledger_date_format]
 
@@ -11,7 +17,9 @@ module Reckon
         if date_format
           begin
             value = Date.strptime(value, date_format)
-          rescue Date::Error
+          # ruby 2.6.0 doesn't have Date::Error, but Date::Error is a subclass of
+          # ArgumentError
+          rescue ArgumentError
             puts "I'm having trouble parsing '#{value}' with the desired format: #{date_format}"
             exit 1
           end
@@ -76,7 +84,11 @@ module Reckon
       begin
         DateTime.parse(entry)
         date_score += 20
-      rescue Date::Error, ArgumentError
+      # ruby 2.6.0 doesn't have Date::Error, but Date::Error is a subclass of
+      # ArgumentError
+      rescue ArgumentError
+        # we don't need do anything here since the column didn't parse as a date
+        nil
       end
 
       date_score

--- a/lib/reckon/version.rb
+++ b/lib/reckon/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reckon
   VERSION = "0.9.1"
 end


### PR DESCRIPTION
Reckon on Ruby 2.6.0 crashes with a message about Date::Error not defined

This PR adds ruby 2.6.0 to the list of rubies to test and fixes the error with #121